### PR TITLE
Remove enroll & print voucher, simplify admin enrollment

### DIFF
--- a/client/pages/admissions/Details.tsx
+++ b/client/pages/admissions/Details.tsx
@@ -42,7 +42,8 @@ export function Details({
             .select("batch_code")
             .order("created_at", { ascending: false });
           if (Array.isArray(data)) {
-            for (const r of data as any[]) if (r.batch_code) set.add(String(r.batch_code));
+            for (const r of data as any[])
+              if (r.batch_code) set.add(String(r.batch_code));
           }
         }
       } catch {}
@@ -52,14 +53,16 @@ export function Details({
           if (res.ok) {
             const p = await res.json();
             const items = Array.isArray(p?.items) ? p.items : [];
-            for (const it of items) if (it?.batch_code) set.add(String(it.batch_code));
+            for (const it of items)
+              if (it?.batch_code) set.add(String(it.batch_code));
           }
         } catch {}
       }
       if (set.size === 0) {
         try {
           const { studentsMock } = await import("@/pages/students/data");
-          for (const s of studentsMock) if (s.admission?.batch) set.add(String(s.admission.batch));
+          for (const s of studentsMock)
+            if (s.admission?.batch) set.add(String(s.admission.batch));
         } catch {}
       }
       const list = Array.from(set).sort();
@@ -175,7 +178,6 @@ export function Details({
     toast({ title: kind === "sms" ? "SMS sent" : "Email sent" });
   };
 
-
   const printForm = () => {
     const w = window.open("", "_blank");
     if (!w) return;
@@ -256,7 +258,6 @@ export function Details({
       </div>
       <Separator />
 
-
       <div className="space-y-2">
         <div className="text-xs text-muted-foreground">Enroll Student</div>
         <Label>Batch</Label>
@@ -279,10 +280,11 @@ export function Details({
 
       <Separator />
 
-
       <div className="flex flex-wrap gap-2">
         <Button onClick={confirmAdmission}>Approve & Move to Students</Button>
-        <Button variant="outline" onClick={markAllPaid}>Mark as Paid</Button>
+        <Button variant="outline" onClick={markAllPaid}>
+          Mark as Paid
+        </Button>
         <Button variant="destructive" onClick={() => onDelete?.(rec)}>
           Delete
         </Button>


### PR DESCRIPTION
## Purpose

The user requested to completely remove the "enroll and print voucher" button functionality and simplify the admin enrollment process. When an admin enrolls a student, they should see all available batches in a dropdown to select from, and enrolled students should appear in the admission tab.

## Code changes

- **Removed quick enrollment functionality**: Eliminated the complex "Enroll & Print Voucher" button and all related state management for quick course enrollment
- **Simplified enrollment UI**: Replaced multiple input fields with a single batch selection dropdown
- **Dynamic batch loading**: Added useEffect to fetch available batches from multiple data sources (Supabase, API, mock data)
- **Streamlined enrollment flow**: Changed enrollment to only require batch selection, removing course selection, amount input, and campus transfer options
- **Removed print voucher functionality**: Completely removed the `printVoucher` and `quickEnrollAndVoucher` functions
- **Cleaned up imports**: Removed unused imports including Input component, navigation, courses data, and payment status utilities
- **Simplified admission confirmation**: Updated the enrollment process to be more straightforward without automatic navigationTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 8`

🔗 [Edit in Builder.io](https://builder.io/app/projects/f3bfecef4f614a2e9fbd999c4d94e59a/vibe-nest)

👀 [Preview Link](https://f3bfecef4f614a2e9fbd999c4d94e59a-vibe-nest.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>f3bfecef4f614a2e9fbd999c4d94e59a</projectId>-->
<!--<branchName>vibe-nest</branchName>-->